### PR TITLE
Feat/add des loc optimizer

### DIFF
--- a/torchft/local_sgd.py
+++ b/torchft/local_sgd.py
@@ -8,6 +8,7 @@ LocalSGD
 =========
 This module implements a fault tolerant version of LocalSGD and related methods.
 """
+
 import logging
 import math
 import threading
@@ -40,6 +41,16 @@ def extract_local_tensor(t: torch.Tensor) -> torch.Tensor:
         new_tensor = t.clone()
     new_tensor.grad = None
     return new_tensor
+
+
+def _calculate_flat_l2_norm(tensors: list[torch.Tensor]) -> float:
+    """Flattens a list of tensors into a single vector and computes its L2 norm."""
+    if not tensors:
+        return 0.0
+    # Move all tensors to the same device (CPU) for concatenation
+    device = tensors[0].device
+    flat_vector = torch.cat([t.view(-1).to(device) for t in tensors])
+    return torch.linalg.norm(flat_vector).item()
 
 
 class LocalSGD:
@@ -159,6 +170,412 @@ class LocalSGD:
         for work in works:
             work.wait()
         return averaged_parameters
+
+
+class _ParameterFragment:
+    """Manages the state and synchronization for model parameters."""
+
+    def __init__(
+        self,
+        manager: Manager,
+        model: nn.Module,
+        sync_every: int,
+        backup_device: torch.device | None,
+        pin_memory: bool,
+        debug_mode: bool = True,
+    ):
+        self._manager = manager
+        self._model = model
+        self.sync_every = sync_every
+        self._backup_device = backup_device
+        self._pin_memory = pin_memory
+        self._debug_mode = debug_mode
+
+        self._local_step = 0
+        self._original_parameters: dict[str, torch.Tensor] = {}
+        self._averaged_parameters: list[torch.Tensor] = []
+
+        self._init_backup_storage()
+        self.save_state()
+
+    def _init_backup_storage(self) -> None:
+        for name, p in self._model.named_parameters():
+            t = torch.empty_like(
+                extract_local_tensor(p.data), device=self._backup_device
+            )
+            if (
+                self._pin_memory
+                and t.device.type == "cpu"
+                and torch.cuda.is_available()
+            ):
+                t = t.pin_memory()
+            self._original_parameters[name] = t
+
+    def save_state(self) -> None:
+        with torch.no_grad():
+            for name, p in self._model.named_parameters():
+                self._original_parameters[name].copy_(
+                    extract_local_tensor(p.data), non_blocking=True
+                )
+
+    def restore_state(self) -> None:
+        with torch.no_grad():
+            for name, p in self._model.named_parameters():
+                if isinstance(p, DTensor):
+                    p.data.copy_(
+                        DTensor.from_local(
+                            self._original_parameters[name],
+                            p.device_mesh,
+                            p.placements,
+                            shape=p.shape,
+                            stride=p.stride(),
+                        )
+                    )
+                else:
+                    p.data.copy_(self._original_parameters[name])
+
+    def prepare_sync(self) -> list[Any]:
+        self._averaged_parameters.clear()
+        allreduce_work = []
+        for p in self._model.parameters():
+            avg_param = extract_local_tensor(p.data)
+            allreduce_work.append(self._manager.allreduce(avg_param))
+            self._averaged_parameters.append(avg_param)
+        return allreduce_work
+
+    def perform_sync(self) -> None:
+        with torch.no_grad():
+            pre_tensors = [p.data.clone() for p in self._model.parameters()]
+            post_tensors = []
+
+            for param, avg_param in zip(
+                self._model.parameters(), self._averaged_parameters
+            ):
+                if isinstance(param, DTensor):
+                    param.data.copy_(
+                        DTensor.from_local(
+                            avg_param,
+                            param.device_mesh,
+                            param.placements,
+                            shape=param.shape,
+                            stride=param.stride(),
+                        )
+                    )
+                else:
+                    param.data.copy_(avg_param)
+                post_tensors.append(param.data)
+            if self._debug_mode:
+                norm_before = _calculate_flat_l2_norm(pre_tensors)
+                norm_after = _calculate_flat_l2_norm(post_tensors)
+
+                flat_before = torch.cat([t.view(-1) for t in pre_tensors])
+                flat_after = torch.cat([t.view(-1) for t in post_tensors])
+                norm_delta = torch.linalg.norm(flat_after - flat_before).item()
+
+                print(
+                    f"DEBUG(Sync): Parameters | "
+                    f"Norm Before: {norm_before:.6f}, "
+                    f"Norm After: {norm_after:.6f}, "
+                    f"Delta Norm: {norm_delta:.6f}"
+                )
+
+    def register_state_dict_fn(self) -> None:
+        def load_fn(state_dict: dict[str, torch.Tensor]) -> None:
+            for name, param in state_dict.items():
+                if name in self._original_parameters:
+                    self._original_parameters[name].copy_(param)
+
+        def save_fn() -> dict[str, torch.Tensor]:
+            return self._original_parameters
+
+        self._manager.register_state_dict_fn(
+            "DesLoc_ParameterFragment", load_fn, save_fn
+        )
+
+
+class _OptimizerStateFragment:
+    """Manages the state and synchronization for a single optimizer state (e.g., 'exp_avg')."""
+
+    def __init__(
+        self,
+        manager: Manager,
+        model: nn.Module,  # FIX: Pass the model to get parameter names
+        optimizer: optim.Optimizer,
+        state_key: str,
+        sync_every: int,
+        backup_device: torch.device | None,
+        debug_mode: bool = True,  # ADDED: debug_mode parameter
+    ):
+        self._manager = manager
+        self._model = model  # Store the model
+        self._optimizer = optimizer
+        self.state_key = state_key
+        self.sync_every = sync_every
+        self._backup_device = backup_device
+        self._debug_mode = debug_mode  # ADDED: Store debug_mode
+
+        self._local_step = 0
+        # FIX: The backup dictionary now uses stable string names as keys
+        self._original_state_tensors: dict[str, torch.Tensor] = {}
+        self._averaged_state_tensors: list[torch.Tensor] = []
+        # FIX: Create a map from name to parameter object for easy lookup
+        self._param_map = {name: p for name, p in self._model.named_parameters()}
+
+        self._init_backup_storage()
+        self.save_state()
+
+    def _init_backup_storage(self) -> None:
+        # Iterate through the model's named parameters to get stable names
+        for name, p in self._model.named_parameters():
+            if (
+                p in self._optimizer.state
+                and self.state_key in self._optimizer.state[p]
+            ):
+                # Use the parameter's name as the key
+                self._original_state_tensors[name] = torch.empty_like(
+                    self._optimizer.state[p][self.state_key], device=self._backup_device
+                )
+
+    def save_state(self) -> None:
+        with torch.no_grad():
+            # Use the name to look up the parameter object
+            for name, backup_tensor in self._original_state_tensors.items():
+                p = self._param_map[name]
+                backup_tensor.copy_(self._optimizer.state[p][self.state_key])
+
+    def restore_state(self) -> None:
+        with torch.no_grad():
+            for name, backup_tensor in self._original_state_tensors.items():
+                p = self._param_map[name]
+                # Defensively check if the state still exists on the live optimizer
+                if (
+                    p in self._optimizer.state
+                    and self.state_key in self._optimizer.state[p]
+                ):
+                    self._optimizer.state[p][self.state_key].copy_(backup_tensor)
+
+    def prepare_sync(self) -> list[Any]:
+        self._averaged_state_tensors.clear()
+        allreduce_work = []
+        # Iterate using the stable names to look up parameters
+        for name in self._original_state_tensors:
+            p = self._param_map[name]
+            state_tensor = self._optimizer.state[p][self.state_key]
+            avg_state = state_tensor.clone().detach()
+            allreduce_work.append(self._manager.allreduce(avg_state))
+            self._averaged_state_tensors.append(avg_state)
+        return allreduce_work
+
+    def perform_sync(self) -> None:
+        with torch.no_grad():
+            pre_tensors = [
+                self._optimizer.state[self._param_map[name]][self.state_key].clone()
+                for name in self._original_state_tensors
+            ]
+            post_tensors = []
+            # The list of names defines the order
+            param_names_with_state = list(self._original_state_tensors.keys())
+            for i, name in enumerate(param_names_with_state):
+                p = self._param_map[name]
+                self._optimizer.state[p][self.state_key].copy_(
+                    self._averaged_state_tensors[i]
+                )
+                post_tensors.append(self._optimizer.state[p][self.state_key])
+
+            if self._debug_mode:
+                norm_before = _calculate_flat_l2_norm(pre_tensors)
+                norm_after = _calculate_flat_l2_norm(post_tensors)
+
+                flat_before = torch.cat([t.view(-1) for t in pre_tensors])
+                flat_after = torch.cat([t.view(-1) for t in post_tensors])
+                norm_delta = torch.linalg.norm(flat_after - flat_before).item()
+
+                print(
+                    f"DEBUG(Sync): Opt State '{self.state_key}' | "
+                    f"Norm Before: {norm_before:.6f}, "
+                    f"Norm After: {norm_after:.6f}, "
+                    f"Delta Norm: {norm_delta:.6f}"
+                )
+
+    def register_state_dict_fn(self) -> None:
+        key = f"DesLoc_OptimizerStateFragment_{self.state_key}"
+
+        # The state_dict is now safe to serialize as it contains string keys
+        def load_fn(state_dict: dict[str, torch.Tensor]) -> None:
+            self._original_state_tensors = state_dict
+
+        def save_fn() -> dict[str, torch.Tensor]:
+            return self._original_state_tensors
+
+        self._manager.register_state_dict_fn(key, load_fn, save_fn)
+
+
+## --- Main Coordinator Class ---
+
+
+class DesLoc:
+    """
+    Implements a fault-tolerant algorithm for synchronizing model parameters and
+    optimizer states at different frequencies, using a modular fragment architecture
+    with lazy initialization for optimizer states.
+    """
+
+    def __init__(
+        self,
+        manager: Manager,
+        model: nn.Module,
+        optimizer: optim.Optimizer,
+        param_sync_every: int,
+        optimizer_sync_every: list[int],
+        backup_device: torch.device | None = None,
+        pin_memory: bool = True,
+        debug_mode: bool = True,  # ADDED: debug_mode parameter
+    ):
+        if manager._use_async_quorum:
+            raise ValueError(
+                "DesLoc requires synchronous quorum. "
+                "Ensure the manager is initialized with use_async_quorum=False."
+            )
+
+        self._manager = manager
+        self._local_optimizer = optimizer
+        self._hooks: list[RemovableHandle] = []
+        self._allreduce_work: list[Any] = []
+        self._fragments: list[_ParameterFragment | _OptimizerStateFragment] = []
+
+        # --- Deferred Initialization State ---
+        self._is_opt_init = False
+        self._opt_sync_every_for_lazy_init = optimizer_sync_every
+        self._backup_device_for_lazy_init = backup_device
+        self._model_for_lazy_init = model  # You already have this
+        self._debug_mode_for_lazy_init = (
+            debug_mode  # ADDED: Store debug_mode for lazy init
+        )
+
+        # Create the parameter fragment immediately.
+        param_fragment = _ParameterFragment(
+            manager,
+            model,
+            param_sync_every,
+            backup_device,
+            pin_memory,
+            debug_mode=debug_mode,
+        )
+        self._fragments.append(param_fragment)
+        param_fragment.register_state_dict_fn()
+
+    def _lazy_init_optimizer_fragments(self) -> None:
+        """
+        Initializes optimizer state fragments after the first real optimizer step.
+        This ensures the optimizer state is populated before we inspect it.
+        """
+        # --- FIX: Robustly discover all non-scalar tensor state keys ---
+        all_state_keys = set()
+        for p_state in self._local_optimizer.state.values():
+            for key, value in p_state.items():
+                # We only sync states that are non-scalar tensors.
+                # This naturally excludes the 'step' counter and other scalar states.
+                if isinstance(value, torch.Tensor) and value.numel() > 1:
+                    all_state_keys.add(key)
+
+        state_keys = sorted(list(all_state_keys))
+
+        if not state_keys:
+            if self._opt_sync_every_for_lazy_init:
+                logger.warning(
+                    "optimizer_sync_every was provided, but no non-scalar "
+                    "tensor states were found in the optimizer (e.g., vanilla SGD)."
+                )
+            self._is_opt_init = True
+            return
+
+        if len(state_keys) != len(self._opt_sync_every_for_lazy_init):
+            raise ValueError(
+                f"Mismatch between number of detected optimizer states ({len(state_keys)}) "
+                f"and length of optimizer_sync_every ({len(self._opt_sync_every_for_lazy_init)}). "
+                f"Detected states: {state_keys}"
+            )
+
+        for i, key in enumerate(state_keys):
+            opt_fragment = _OptimizerStateFragment(
+                self._manager,
+                self._model_for_lazy_init,  # Pass the model here
+                self._local_optimizer,
+                key,
+                self._opt_sync_every_for_lazy_init[i],
+                self._backup_device_for_lazy_init,
+                debug_mode=self._debug_mode_for_lazy_init,
+            )
+            self._fragments.append(opt_fragment)
+            opt_fragment.register_state_dict_fn()
+
+        self._is_opt_init = True
+        del self._opt_sync_every_for_lazy_init
+        del self._backup_device_for_lazy_init
+
+    def __enter__(self) -> "DesLoc":
+        self._hooks.append(
+            self._local_optimizer.register_step_post_hook(self._step_post_hook)
+        )
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        for hook in self._hooks:
+            hook.remove()
+        self._hooks.clear()
+        return False
+
+    def _step_post_hook(
+        self, _optim: optim.Optimizer, _args: tuple[Any, ...], _kwargs: dict[str, Any]
+    ) -> None:
+        if not self._is_opt_init:
+            self._lazy_init_optimizer_fragments()
+
+        ready_fragments = []
+        for f in self._fragments:
+            f._local_step += 1
+            if f._local_step >= f.sync_every:
+                ready_fragments.append(f)
+
+        if ready_fragments:
+            self.sync(ready_fragments)
+
+    def sync(
+        self, fragments_to_sync: list[_ParameterFragment | _OptimizerStateFragment]
+    ) -> None:
+        """Orchestrates the synchronization process for the specified fragments."""
+        self._manager.start_quorum()
+        self.prepare_sync(fragments_to_sync)
+        self.perform_sync(fragments_to_sync)
+
+        for f in fragments_to_sync:
+            f._local_step = 0
+
+    def prepare_sync(
+        self, fragments_to_sync: list[_ParameterFragment | _OptimizerStateFragment]
+    ) -> None:
+        self._allreduce_work.clear()
+        for fragment in fragments_to_sync:
+            self._allreduce_work.extend(fragment.prepare_sync())
+
+    def perform_sync(
+        self, fragments_to_sync: list[_ParameterFragment | _OptimizerStateFragment]
+    ) -> None:
+        for work in self._allreduce_work:
+            work.wait()
+
+        if self._manager.should_commit():
+            for fragment in fragments_to_sync:
+                fragment.perform_sync()
+                fragment.save_state()
+        else:
+            for fragment in fragments_to_sync:
+                fragment.restore_state()
 
 
 class _StreamingDiLoCoFragment:
@@ -583,9 +1000,9 @@ class DiLoCo:
         """
 
         if isinstance(outer_optimizer, list):
-            assert len(outer_optimizer) == len(
-                model_fragments
-            ), "The number of outer optimizers must match the number of model fragments"
+            assert len(outer_optimizer) == len(model_fragments), (
+                "The number of outer optimizers must match the number of model fragments"
+            )
 
         if manager._use_async_quorum:
             raise ValueError(
@@ -743,6 +1160,6 @@ class DiLoCo:
             self._local_step = 0
             return
 
-        assert (
-            False
-        ), f"{self._local_step=} should never be greater than {self._sync_every=}"
+        assert False, (
+            f"{self._local_step=} should never be greater than {self._sync_every=}"
+        )

--- a/torchft/test_desloc.py
+++ b/torchft/test_desloc.py
@@ -1,0 +1,278 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import TestCase
+from unittest.mock import MagicMock, create_autospec
+
+import torch
+from torch import nn, optim
+
+from torchft.local_sgd import (
+    _OptimizerStateFragment,
+    _ParameterFragment,
+    DesLoc,
+)
+from torchft.manager import Manager
+
+
+def create_manager() -> MagicMock:
+    """
+    Creates a mock manager with some useful defaults for testing
+    the optimizer's usage of the Manager
+    """
+    manager = create_autospec(Manager)
+    manager._use_async_quorum = False
+    manager.should_commit.return_value = True
+
+    # Mock the allreduce function to average the tensors
+    def mock_allreduce(tensor: torch.Tensor) -> torch.Tensor:
+        # In a real scenario, this would be an allreduce operation.
+        # For testing, we can just return the tensor as is,
+        # or simulate averaging if needed.
+        return tensor
+
+    manager.allreduce.side_effect = mock_allreduce
+    return manager
+
+
+class SimpleModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = nn.Sequential(
+            nn.Linear(10, 20),
+            nn.ReLU(),
+            nn.Linear(20, 5),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.model(x)
+
+
+class DesLocTest(TestCase):
+    def test_desloc_healthy_path(self) -> None:
+        model = SimpleModel()
+        optimizer = optim.AdamW(model.parameters())
+        manager = create_manager()
+
+        param_sync_every = 2
+        optimizer_sync_every = [4]
+
+        with DesLoc(
+            manager, model, optimizer, param_sync_every, optimizer_sync_every
+        ) as desloc:
+            self.assertEqual(len(desloc._fragments), 1)  # Only param fragment initially
+            self.assertFalse(desloc._is_opt_init)
+
+            # --- Step 1 ---
+            optimizer.step()
+            self.assertTrue(desloc._is_opt_init)
+            self.assertEqual(len(desloc._fragments), 3)  # Param + 2 optimizer states for AdamW
+
+            param_fragment = desloc._fragments[0]
+            opt_frag_1 = desloc._fragments[1]
+            opt_frag_2 = desloc._fragments[2]
+
+            self.assertEqual(param_fragment._local_step, 1)
+            self.assertEqual(opt_frag_1._local_step, 1)
+            self.assertEqual(opt_frag_2._local_step, 1)
+            self.assertEqual(manager.start_quorum.call_count, 0)
+
+            # --- Step 2 (Param Sync) ---
+            optimizer.step()
+            self.assertEqual(param_fragment._local_step, 0)  # Reset after sync
+            self.assertEqual(opt_frag_1._local_step, 2)
+            self.assertEqual(opt_frag_2._local_step, 2)
+            self.assertEqual(manager.start_quorum.call_count, 1)
+            self.assertEqual(manager.should_commit.call_count, 1)
+            # 4 params in SimpleModel, so 4 allreduce calls
+            self.assertEqual(manager.allreduce.call_count, 4)
+
+            # --- Step 3 ---
+            optimizer.step()
+            self.assertEqual(param_fragment._local_step, 1)
+            self.assertEqual(opt_frag_1._local_step, 3)
+            self.assertEqual(opt_frag_2._local_step, 3)
+            self.assertEqual(manager.start_quorum.call_count, 1)
+
+            # --- Step 4 (Param + Optimizer Sync) ---
+            manager.allreduce.reset_mock()
+            optimizer.step()
+            self.assertEqual(param_fragment._local_step, 0)
+            self.assertEqual(opt_frag_1._local_step, 0)
+            self.assertEqual(opt_frag_2._local_step, 0)
+            self.assertEqual(manager.start_quorum.call_count, 2)
+            self.assertEqual(manager.should_commit.call_count, 2)
+
+            # 4 params + 4 exp_avg + 4 exp_avg_sq = 12 allreduce calls
+            self.assertEqual(manager.allreduce.call_count, 12)
+
+    def test_desloc_recovery_path(self) -> None:
+        model = SimpleModel()
+        optimizer = optim.AdamW(model.parameters())
+        manager = create_manager()
+
+        param_sync_every = 2
+        optimizer_sync_every = [2]
+
+        with DesLoc(
+            manager, model, optimizer, param_sync_every, optimizer_sync_every
+        ) as desloc:
+            # --- Step 1: Run one step to populate optimizer state ---
+            optimizer.step()
+
+            # --- Save current state ---
+            model_state_before_sync = {
+                name: p.clone() for name, p in model.named_parameters()
+            }
+            optimizer_state_before_sync = {
+                id(p): {k: v.clone() for k, v in s.items() if torch.is_tensor(v)}
+                for p, s in optimizer.state.items()
+            }
+
+            # --- Step 2: Trigger sync with failure ---
+            manager.should_commit.return_value = False
+            optimizer.step()
+
+            # --- Verify state restoration ---
+            self.assertEqual(manager.start_quorum.call_count, 1)
+            self.assertEqual(manager.should_commit.call_count, 1)
+
+            # Check model parameters
+            for name, p in model.named_parameters():
+                self.assertTrue(torch.equal(p, model_state_before_sync[name]))
+
+            # Check optimizer state
+            for p, s in optimizer.state.items():
+                for k, v in s.items():
+                    if torch.is_tensor(v):
+                        self.assertTrue(
+                            torch.equal(v, optimizer_state_before_sync[id(p)][k])
+                        )
+
+            # --- Check local step counters ---
+            # They should not be reset because the sync failed
+            for fragment in desloc._fragments:
+                self.assertEqual(fragment._local_step, 2)
+
+    def test_desloc_lazy_init(self) -> None:
+        # --- Test with SGD (no state) ---
+        model_sgd = SimpleModel()
+        optimizer_sgd = optim.SGD(model_sgd.parameters(), lr=0.01)
+        manager_sgd = create_manager()
+
+        with DesLoc(
+            manager_sgd, model_sgd, optimizer_sgd, param_sync_every=2, optimizer_sync_every=[]
+        ) as desloc_sgd:
+            self.assertFalse(desloc_sgd._is_opt_init)
+            self.assertEqual(len(desloc_sgd._fragments), 1)
+
+            optimizer_sgd.step()
+
+            self.assertTrue(desloc_sgd._is_opt_init)
+            # No new fragments should be added for SGD as it has no tensor state
+            self.assertEqual(len(desloc_sgd._fragments), 1)
+
+        # --- Test with AdamW (with state) ---
+        model_adam = SimpleModel()
+        optimizer_adam = optim.AdamW(model_adam.parameters())
+        manager_adam = create_manager()
+
+        with DesLoc(
+            manager_adam,
+            model_adam,
+            optimizer_adam,
+            param_sync_every=2,
+            optimizer_sync_every=[4, 4],
+        ) as desloc_adam:
+            self.assertFalse(desloc_adam._is_opt_init)
+            self.assertEqual(len(desloc_adam._fragments), 1)
+
+            optimizer_adam.step()
+
+            self.assertTrue(desloc_adam._is_opt_init)
+            # AdamW has 'exp_avg' and 'exp_avg_sq' states
+            self.assertEqual(len(desloc_adam._fragments), 3)
+            self.assertIsInstance(desloc_adam._fragments[0], _ParameterFragment)
+            self.assertIsInstance(desloc_adam._fragments[1], _OptimizerStateFragment)
+            self.assertIsInstance(desloc_adam._fragments[2], _OptimizerStateFragment)
+            self.assertEqual(desloc_adam._fragments[1].state_key, "exp_avg")
+            self.assertEqual(desloc_adam._fragments[2].state_key, "exp_avg_sq")
+
+    def test_desloc_sync_correctness(self) -> None:
+        # --- Setup two "workers" ---
+        model1 = SimpleModel()
+        optimizer1 = optim.AdamW(model1.parameters())
+        manager1 = create_manager()
+
+        model2 = SimpleModel()
+        optimizer2 = optim.AdamW(model2.parameters())
+        manager2 = create_manager()
+
+        # --- Set different initial weights for workers ---
+        with torch.no_grad():
+            for p1, p2 in zip(model1.parameters(), model2.parameters()):
+                p1.data.fill_(1.0)
+                p2.data.fill_(3.0)
+
+        param_sync_every = 1
+        optimizer_sync_every = [1]
+
+        with DesLoc(
+            manager1, model1, optimizer1, param_sync_every, optimizer_sync_every
+        ) as desloc1, DesLoc(
+            manager2, model2, optimizer2, param_sync_every, optimizer_sync_every
+        ) as desloc2:
+
+            # --- Manually simulate allreduce ---
+            def simulated_allreduce(deslocs):
+                all_fragments = [d._fragments for d in deslocs]
+                for frags in zip(*all_fragments):
+                    # Simulate parameter sync
+                    if isinstance(frags[0], _ParameterFragment):
+                        params = [list(f._model.parameters()) for f in frags]
+                        for ps in zip(*params):
+                            avg_p = torch.stack([p.data for p in ps]).mean(dim=0)
+                            for p in ps:
+                                p.data.copy_(avg_p)
+                    # Simulate optimizer state sync
+                    elif isinstance(frags[0], _OptimizerStateFragment):
+                        key = frags[0].state_key
+                        states = [
+                            [
+                                f._optimizer.state[p][key]
+                                for p in f._model.parameters()
+                                if p in f._optimizer.state
+                                and key in f._optimizer.state[p]
+                            ]
+                            for f in frags
+                        ]
+                        for ss in zip(*states):
+                            avg_s = torch.stack(ss).mean(dim=0)
+                            for s in ss:
+                                s.copy_(avg_s)
+
+            # --- Run step to trigger sync ---
+            optimizer1.step()
+            optimizer2.step()
+            simulated_allreduce([desloc1, desloc2])
+
+            # --- Verify that parameters are averaged ---
+            for p1, p2 in zip(model1.parameters(), model2.parameters()):
+                self.assertTrue(torch.all(torch.eq(p1, p2)))
+                self.assertTrue(torch.all(torch.eq(p1, torch.full_like(p1, 2.0))))
+
+            # --- Verify that optimizer states are averaged ---
+            # AdamW initializes state lazily, so we need to check after a step
+            optimizer1.step()
+            optimizer2.step()
+            simulated_allreduce([desloc1, desloc2])
+
+            for (p1, s1), (p2, s2) in zip(
+                optimizer1.state.items(), optimizer2.state.items()
+            ):
+                for key in s1:
+                    if torch.is_tensor(s1[key]):
+                        self.assertTrue(torch.equal(s1[key], s2[key]))

--- a/train_desloc.py
+++ b/train_desloc.py
@@ -1,0 +1,139 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+from datetime import timedelta
+
+import torch
+from torch import nn, optim
+from torch.distributed.elastic.multiprocessing.errors import record
+from torch.utils.tensorboard import SummaryWriter
+
+from torchft import Manager, ProcessGroupGloo
+from torchft.checkpointing.pg_transport import PGTransport
+from torchft.local_sgd import DesLoc
+
+logging.basicConfig(level=logging.INFO)
+
+
+@record
+def main() -> None:
+    REPLICA_GROUP_ID = int(os.environ.get("REPLICA_GROUP_ID", 0))
+    RUN = int(os.environ.get("RUN", 0))
+
+    output_folder = f"output/replica-{REPLICA_GROUP_ID}"
+
+    writer = SummaryWriter(f"{output_folder}/tensorboard", max_queue=1000)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    pg = ProcessGroupGloo(timeout=timedelta(seconds=5))
+
+    transport = PGTransport(
+        pg,
+        timeout=timedelta(seconds=10),
+        device=device,
+    )
+
+    class SimpleModel(nn.Module):
+        def __init__(self, d_hid: int, num_classes: int = 10):
+            super().__init__()
+            self.net = nn.Sequential(
+                nn.Linear(d_hid, d_hid),
+                nn.ReLU(),
+                nn.Linear(d_hid, d_hid),
+                nn.ReLU(),
+                nn.Linear(d_hid, num_classes),
+            )
+
+        def forward(self, x):
+            return self.net(x)
+
+    d_hid = 128
+    m = SimpleModel(d_hid).to(device)
+    optimizer = optim.AdamW(m.parameters(), lr=1e-3)
+
+    def load_state_dict(state_dict):
+        m.load_state_dict(state_dict["model"])
+        optimizer.load_state_dict(state_dict["optimizer"])
+
+    def state_dict():
+        return {
+            "model": m.state_dict(),
+            "optimizer": optimizer.state_dict(),
+        }
+
+    manager = Manager(
+        pg=pg,
+        use_async_quorum=False,
+        min_replica_size=1,
+        load_state_dict=load_state_dict,
+        state_dict=state_dict,
+        replica_id=f"train_desloc_{REPLICA_GROUP_ID}",
+        timeout=timedelta(seconds=30),
+        checkpoint_transport=transport,
+    )
+
+    class DummyDataset(torch.utils.data.Dataset):
+        def __init__(self, size=1000, feature_dim=128, num_classes=10):
+            self.size = size
+            self.feature_dim = feature_dim
+            self.num_classes = num_classes
+
+        def __len__(self):
+            return self.size
+
+        def __getitem__(self, idx):
+            features = torch.rand(self.feature_dim)
+            label = torch.randint(0, self.num_classes, (1,)).item()
+            return features, label
+
+    trainset = DummyDataset(feature_dim=d_hid)
+    trainloader = torch.utils.data.DataLoader(
+        trainset, batch_size=32, num_workers=2, shuffle=True
+    )
+
+    criterion = nn.CrossEntropyLoss()
+
+    tensorboard_key_prefix = f"Run:{RUN}"
+    with DesLoc(
+        manager,
+        m,
+        optimizer,
+        param_sync_every=10,
+        optimizer_sync_every=[20, 20],  # For AdamW's exp_avg and exp_avg_sq
+    ) as desloc:
+        while True:
+            for i, (inputs, labels) in enumerate(trainloader):
+                inputs = inputs.to(device)
+                labels = labels.to(device)
+
+                optimizer.zero_grad()
+                out = m(inputs)
+                loss = criterion(out, labels)
+                loss.backward()
+                optimizer.step()
+
+                writer.add_scalar(f"{tensorboard_key_prefix}/loss", loss, i)
+                writer.add_scalar(
+                    f"{tensorboard_key_prefix}/num_participants",
+                    manager.num_participants(),
+                    i,
+                )
+                writer.add_scalar(
+                    f"{tensorboard_key_prefix}/current_step", manager.current_step(), i
+                )
+                if manager.current_step() % 10 == 0:
+                    print(f"[{manager.current_step()}] loss = {loss.item()}")
+
+                if manager.current_step() >= 100:
+                    # complete training
+                    writer.flush()
+                    exit()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a new integration test suite for the `DesLoc` local SGD optimizer and adds an example training script that demonstrates how to use `DesLoc` in a distributed setting. The changes provide both thorough unit tests for `DesLoc`'s synchronization logic and a practical, runnable example for end-to-end training with checkpointing and monitoring.

**New test coverage for `DesLoc`:**

* Added `torchft/test_desloc.py`, a comprehensive test suite for the `DesLoc` optimizer wrapper, covering healthy path, recovery from failed sync, lazy initialization for different optimizers, and correctness of parameter/state synchronization across workers.

**Example script for distributed training:**

* Added `train_desloc.py`, an end-to-end example script that sets up a distributed training loop using `DesLoc`, `Manager`, and `ProcessGroupGloo`, with dummy data, checkpointing, and TensorBoard logging. This script illustrates real-world usage and integration of the local SGD optimizer in a multi-replica environment.